### PR TITLE
Single daily entry

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,6 +54,7 @@ app.post('/api/login', index.POSTlogin);
 app.post('/api/logout', index.POSTlogout);
 app.post('/api/register', index.POSTregister);
 app.get('/api/allStudents', index.GETallStudents);
+app.get('/api/student/allEntries', index.GETallStudentEntries);
 app.get('/api/student/:_id', index.GETstudent);
 app.post('/api/student/add', index.POSTaddstudent);
 app.post('/api/student/edit/:_id', index.POSTeditstudent);

--- a/public/javascripts/ngApp.js
+++ b/public/javascripts/ngApp.js
@@ -104,7 +104,7 @@ springInitiative.run(function($rootScope, $state, $http) {
       $http.get('/user').then(function(data) {
         if (data.data.user == null) {
           console.log('No one logged in, redirecting to /login');
-          // $state.go('login');
+          $state.go('login');
         }
       }, function(err) {
         console.log('Error: in GET \'/user\'', err);

--- a/public/javascripts/ngApp.js
+++ b/public/javascripts/ngApp.js
@@ -104,7 +104,7 @@ springInitiative.run(function($rootScope, $state, $http) {
       $http.get('/user').then(function(data) {
         if (data.data.user == null) {
           console.log('No one logged in, redirecting to /login');
-          $state.go('login');
+          // $state.go('login');
         }
       }, function(err) {
         console.log('Error: in GET \'/user\'', err);

--- a/public/javascripts/studentControllers.js
+++ b/public/javascripts/studentControllers.js
@@ -43,6 +43,17 @@ var addDailyEntryController = function($scope, $http, $location) {
       console.log('Error: ' + response.data);
       $scope.entrySubmittedMsg = response.data.msg;
     });
+  };
+
+  $scope.dateChange = function() {
+    var req = {studentID: $scope.currentStudent._id, date: $scope.newDailyEntry.date};
+    console.log(req)
+    $http.get('/api/student/allEntries', {params: req})
+    .then(function successCallback(response) {
+      console.log(response);
+    }, function errorCallback(response) {
+        console.log('Error: ' + response.data);
+    });
   }
 }
 

--- a/public/javascripts/studentControllers.js
+++ b/public/javascripts/studentControllers.js
@@ -45,15 +45,58 @@ var addDailyEntryController = function($scope, $http, $location) {
     });
   };
 
+  var req = {studentID: $scope.currentStudent._id};
+  console.log(req)
+  $http.get('/api/student/allEntries', {params: req})
+  .then(function successCallback(response) {
+    $scope.allEntries = response.data;
+    console.log(response);
+  }, function errorCallback(response) {
+      console.log('Error: ' + response.data);
+  });
+
   $scope.dateChange = function() {
-    var req = {studentID: $scope.currentStudent._id, date: $scope.newDailyEntry.date};
-    console.log(req)
-    $http.get('/api/student/allEntries', {params: req})
-    .then(function successCallback(response) {
-      console.log(response);
-    }, function errorCallback(response) {
-        console.log('Error: ' + response.data);
+    var dateMatch = -1;
+    console.log($scope.allEntries)
+    $scope.allEntries.forEach(function (entry, i) {
+      var date = entry.date;
+      var year1 = date.substring(0, 4);
+      var month1 = date.substring(5, 7);
+      var day1 = date.substring(8, 10);
+      var year2 = $scope.newDailyEntry.date.substring(6, 10)
+      var month2 = $scope.newDailyEntry.date.substring(0, 2)
+      var day2 = $scope.newDailyEntry.date.substring(3, 5)
+      if (year1 == year2 && month1 == month2 && day1 == day2) {
+        dateMatch = i;
+      }
     });
+    if (dateMatch !== -1)
+    {
+      var prepopulate = window.confirm("A entry for this date already exists. Would you like to edit your existing entry?");
+      if (prepopulate)
+      {
+        var currentDate = $scope.allEntries[dateMatch];
+        $scope.newDailyEntry.attendance = currentDate.attendance;
+        $scope.newDailyEntry.behaviorText = currentDate.behaviorText;
+        $scope.newDailyEntry.warnings = currentDate.warnings;
+        $scope.newDailyEntry.stars = currentDate.stars;
+        if ($scope.newDailyEntry.schoolBehavior == null) {
+          $scope.newDailyEntry.schoolBehavior = {}
+        }
+        $scope.newDailyEntry.schoolBehavior['Write-Up'] = currentDate.schoolBehavior['Write-Up'];
+        $scope.newDailyEntry.schoolBehavior['Detention'] = currentDate.schoolBehavior['Detention'];
+        $scope.newDailyEntry.schoolBehavior['In-School Suspension'] = currentDate.schoolBehavior['In-School Suspension'];
+        $scope.newDailyEntry.schoolBehavior['Out-of-School Suspension'] = currentDate.schoolBehavior['Out-of-School Suspension'];
+        $scope.newDailyEntry.actionSteps = currentDate.actionSteps;
+        $scope.newDailyEntry.teacherFeedback = currentDate.teacherFeedback;
+        $scope.newDailyEntry.engageContent = currentDate.engageContent;
+        $scope.newDailyEntry.engagePeer = currentDate.engagePeer;
+      }
+      else {
+        $scope.newDailyEntry.date = null;
+      }
+    }
+    console.log($scope.newDailyEntry.date)
   }
 }
 

--- a/public/views/content/dailyEntry.html
+++ b/public/views/content/dailyEntry.html
@@ -4,7 +4,7 @@
     <div class="col-sm-6">
       <div class="form-group">
         <label for="date">Date:</label>
-        <input data-provide="datepicker" type="text" class="form-control datepicker" ng-model="newDailyEntry.date" value="{{ date | date: 'mm/dd/yyyy' }}">
+        <input data-provide="datepicker" type="text" class="form-control datepicker" ng-model="newDailyEntry.date" value="{{ date | date: 'mm/dd/yyyy' }}" ng-change="dateChange();">
       </div>
 
       <div class="form-group">

--- a/public/views/content/dailyEntry.html
+++ b/public/views/content/dailyEntry.html
@@ -4,12 +4,12 @@
     <div class="col-sm-6">
       <div class="form-group">
         <label for="date">Date:</label>
-        <input data-provide="datepicker" type="text" class="form-control datepicker" ng-model="newDailyEntry.date" value="{{ date | date: 'mm/dd/yyyy' }}" ng-change="dateChange();">
+        <input data-provide="datepicker" type="text" class="form-control datepicker" ng-model="newDailyEntry.date" value="{{ date | date: 'mm/dd/yyyy' }}" ng-change="dateChange();" required>
       </div>
 
       <div class="form-group">
         <label for="sel1">Attendance:</label>
-        <select class="form-control" id="sel1" ng-model="newDailyEntry.attendance">
+        <select class="form-control" id="sel1" ng-model="newDailyEntry.attendance" ng-disabled="!newDailyEntry.date">
           <option value="Present">Present</option>
           <option value="Absent">Absent</option>
           <option value="Suspended">Suspended</option>
@@ -19,12 +19,12 @@
 
       <div class="form-group">
         <label>Behavior at Spring Today:</label>
-        <input type="text" ng-model="newDailyEntry.behaviorText" placeholder="John Doe was ..." class="form-control" required/>
+        <input type="text" ng-model="newDailyEntry.behaviorText" placeholder="John Doe was ..." class="form-control" ng-disabled="!newDailyEntry.date"/>
       </div>
 
       <div class="form-group">
         <label for="sel1">Warnings at Spring:</label>
-        <select class="form-control" id="sel1" ng-model="newDailyEntry.warnings">
+        <select class="form-control" id="sel1" ng-disabled="!newDailyEntry.date" ng-model="newDailyEntry.warnings">
           <option value=""></option>
           <option value="1 Warning">1 Warning</option>
           <option value="2 Warnings">2 Warnings</option>
@@ -35,7 +35,7 @@
 
       <div class="form-group">
         <label for="sel1">Stars at Spring:</label>
-        <select class="form-control" id="sel1" ng-model="newDailyEntry.stars">
+        <select class="form-control" id="sel1" ng-model="newDailyEntry.stars" ng-disabled="!newDailyEntry.date">
           <option value="0">0</option>
           <option value="1">1</option>
           <option value="2">2</option>
@@ -49,44 +49,44 @@
         <label>Issues at School:</label>
         <div class="checkbox">
           <label>
-            <input type="checkbox" ng-model="newDailyEntry.schoolBehavior['Write-Up']" value="Write-Up">Write-Up</label>
+            <input type="checkbox" ng-model="newDailyEntry.schoolBehavior['Write-Up']" value="Write-Up" ng-disabled="!newDailyEntry.date">Write-Up</label>
         </div>
         <div class="checkbox">
           <label>
-            <input type="checkbox" ng-model="newDailyEntry.schoolBehavior['Detention']" value="Detention">Detention</label>
+            <input type="checkbox" ng-model="newDailyEntry.schoolBehavior['Detention']" value="Detention" ng-disabled="!newDailyEntry.date">Detention</label>
         </div>
         <div class="checkbox">
           <label>
-            <input type="checkbox" ng-model="newDailyEntry.schoolBehavior['In-School Suspension']" value="In-School Suspension">In-School Suspension</label>
+            <input type="checkbox" ng-model="newDailyEntry.schoolBehavior['In-School Suspension']" value="In-School Suspension" ng-disabled="!newDailyEntry.date">In-School Suspension</label>
         </div>
         <div class="checkbox">
           <label>
-            <input type="checkbox" ng-model="newDailyEntry.schoolBehavior['Out-of-School Suspension']" value="Out-of-School Suspension">Out-of-School Suspension</label>
+            <input type="checkbox" ng-model="newDailyEntry.schoolBehavior['Out-of-School Suspension']" value="Out-of-School Suspension" ng-disabled="!newDailyEntry.date">Out-of-School Suspension</label>
         </div>
       </div>
 
       <div class="form-group">
         <label>Action Steps:</label>
-        <input type="text" ng-model="newDailyEntry.actionSteps" placeholder="Input action steps" class="form-control" />
+        <input type="text" ng-model="newDailyEntry.actionSteps" placeholder="Input action steps" class="form-control" ng-disabled="!newDailyEntry.date"/>
       </div>
 
       <div class="form-group">
         <label>Teacher Feedback:</label>
-        <input type="text" ng-model="newDailyEntry.teacherFeedback" placeholder="Input any teacher feedback." class="form-control" />
+        <input type="text" ng-model="newDailyEntry.teacherFeedback" placeholder="Input any teacher feedback." class="form-control" ng-disabled="!newDailyEntry.date"/>
       </div>
 
       <div class="form-group">
         <label>Engaging with content:</label>
-        <input type="number" ng-model="newDailyEntry.engageContent" />
+        <input type="number" ng-model="newDailyEntry.engageContent" ng-disabled="!newDailyEntry.date"/>
         <br/>
-        <rzslider rz-slider-model="newDailyEntry.engageContent"></rzslider>
+        <rzslider rz-slider-model="newDailyEntry.engageContent" ng-disabled="!newDailyEntry.date"></rzslider>
       </div>
 
       <div class="form-group">
         <label>Engaging with peers:</label>
-        <input type="number" ng-model="newDailyEntry.engagePeer" />
+        <input type="number" ng-model="newDailyEntry.engagePeer" ng-disabled="!newDailyEntry.date"/>
         <br/>
-        <rzslider rz-slider-model="newDailyEntry.engagePeer"></rzslider>
+        <rzslider rz-slider-model="newDailyEntry.engagePeer" ng-disabled="!newDailyEntry.date"></rzslider>
       </div>
     </div>
   </div>

--- a/routes/entryRoutes.js
+++ b/routes/entryRoutes.js
@@ -67,11 +67,9 @@ routes.POSTnewLongEntry = function(req, res, next) {
 
 routes.GETallStudentEntries = function(req, res) {
   var studentID = req.query.studentID;
-  var date = req.query.date;
-  console.log(date)
-  console.log(JSON.stringify(req.query))
-  FormDB.findOne({_studentID:studentID, date:date}, function(err, entries) {
-    console.log(entries);
+  FormDB.find({_studentID:studentID}, function(err, entries) {
+    //TODO: err
+    res.json(entries);
   });
 
 }
@@ -84,10 +82,7 @@ routes.GETstudentEntries = function(req, res) {
   var behaviorList = [];
   var warningList = [];
 
-  console.log('poop2')
-
   FormDB.find({_studentID:studentID}, function(err, studentData) {
-    console.log(studentData)
     for (var i = 0; i < studentData.length; i++){
       attendanceList.push(studentData[i].attendance);
       starsList.push(studentData[i].stars);

--- a/routes/entryRoutes.js
+++ b/routes/entryRoutes.js
@@ -7,7 +7,7 @@ routes.POSTnewDailyEntry = function(req, res, next) {
   // This route only handles short term
   var studentID = req.params._id;
   var period = 'Daily';
-  var date = req.body.date.slice(0,10);
+  var date = req.body.date;
   var currentDate = Date.parse(date);
   var attendance = req.body.attendance;
   var behaviorText = req.body.behaviorText;
@@ -18,7 +18,7 @@ routes.POSTnewDailyEntry = function(req, res, next) {
   var stars = req.body.stars;
   var engageContent = parseInt(req.body.engageContent);
   var engagePeer = parseInt(req.body.engagePeer);
-  FormDB.create({
+  var querry = {
     _studentID: studentID,
     date: currentDate,
     period: period,
@@ -31,12 +31,19 @@ routes.POSTnewDailyEntry = function(req, res, next) {
     stars: stars,
     engageContent: engageContent,
     engagePeer: engagePeer
-  }, function(err, newEntryObj) {
+  }
+  var callback = function(err, newEntryObj) {
     if (err) {
       return res.status(500).json({msg: 'Error submitting entry'});
     }
     res.json({newEntryObj:newEntryObj, msg: 'Entry submitted successfully!'});
-  })
+  };
+  if (req.body._id == null) {
+    FormDB.create(querry, callback)
+  } else {
+    console.log('UPDATING')
+    FormDB.findByIdAndUpdate(req.body._id, {$set: querry}, {new: true}, callback);
+  }
 };
 
 routes.POSTnewLongEntry = function(req, res, next) {

--- a/routes/entryRoutes.js
+++ b/routes/entryRoutes.js
@@ -74,7 +74,8 @@ routes.POSTnewLongEntry = function(req, res, next) {
 routes.GETallStudentEntries = function(req, res) {
   var studentID = req.query.studentID;
   FormDB.find({_studentID:studentID}, function(err, entries) {
-    //TODO: err
+    if (err)
+      res.sendStatus(500);
     res.json(entries);
   });
 

--- a/routes/entryRoutes.js
+++ b/routes/entryRoutes.js
@@ -41,7 +41,6 @@ routes.POSTnewDailyEntry = function(req, res, next) {
   if (req.body._id == null) {
     FormDB.create(querry, callback)
   } else {
-    console.log('UPDATING')
     FormDB.findByIdAndUpdate(req.body._id, {$set: querry}, {new: true}, callback);
   }
 };

--- a/routes/entryRoutes.js
+++ b/routes/entryRoutes.js
@@ -65,7 +65,18 @@ routes.POSTnewLongEntry = function(req, res, next) {
   })
 };
 
-routes.GETstudentEntries = function(req, res){
+routes.GETallStudentEntries = function(req, res) {
+  var studentID = req.query.studentID;
+  var date = req.query.date;
+  console.log(date)
+  console.log(JSON.stringify(req.query))
+  FormDB.findOne({_studentID:studentID, date:date}, function(err, entries) {
+    console.log(entries);
+  });
+
+}
+
+routes.GETstudentEntries = function(req, res) {
   var studentID = req.params._id;
   var attendanceList = [];
   var starsList = [];
@@ -73,7 +84,10 @@ routes.GETstudentEntries = function(req, res){
   var behaviorList = [];
   var warningList = [];
 
-  FormDB.find({_studentID:studentID}, function(err, studentData){
+  console.log('poop2')
+
+  FormDB.find({_studentID:studentID}, function(err, studentData) {
+    console.log(studentData)
     for (var i = 0; i < studentData.length; i++){
       attendanceList.push(studentData[i].attendance);
       starsList.push(studentData[i].stars);

--- a/routes/index.js
+++ b/routes/index.js
@@ -25,6 +25,7 @@ routes.DELETEdelUser = userRoutes.DELETEdelUser;
 routes.POSTnewDailyEntry = entryRoutes.POSTnewDailyEntry;
 routes.POSTnewLongEntry = entryRoutes.POSTnewLongEntry;
 routes.GETstudentEntries = entryRoutes.GETstudentEntries;
+routes.GETallStudentEntries = entryRoutes.GETallStudentEntries;
 
 routes.POSTnewCohortEntry = cohortRoutes.POSTnewCohortEntry;
 


### PR DESCRIPTION
It's finally here! Now, when the user clicks a date on the calendar for which there already is a daily entry, the app prompts the user to prepopulate the form with the previous entry. When you hit submit, the daily entry is updated server side, rather than creating a new one. All previous functionality is still intact. Also, all form inputs are disabled before you select a date, to prevent work from being overwritten.
